### PR TITLE
Update the OData server's processing of incoming JSON DateTimeOffsets

### DIFF
--- a/pyslet/odata2/core.py
+++ b/pyslet/odata2/core.py
@@ -10,6 +10,7 @@ import uuid
 import math
 import warnings
 import io
+import datetime
 from types import *
 
 from pyslet.unicode5 import CharClass, detect_encoding
@@ -2763,6 +2764,15 @@ def ReadEntityPropertyValueInJSON(v, jsonValue):
             t, overflow = Time().offset(
                 seconds=int(ticks[0]) / 1000.0).with_zone(zdir, zoffset // 60, zoffset % 60)
             d = Date(absolute_day=BASE_DAY + overflow)
+            v.set_from_value(iso.TimePoint(date=d, time=t))
+        elif jsonValue.endswith('Z'):
+            # Parse the incoming date using the ISO 8601 format
+            naive_datetime = datetime.datetime.strptime(jsonValue, '%Y-%m-%dT%H:%M:%S.%fZ')
+            total_seconds = (naive_datetime - datetime.datetime.utcfromtimestamp(0)).total_seconds()
+            t, overflow = iso.Time().offset(
+                seconds=total_seconds)
+            t = t.with_zone(0, 0, 0)
+            d = iso.Date(absolute_day=BASE_DAY + overflow)
             v.set_from_value(iso.TimePoint(date=d, time=t))
         else:
             raise ValueError(


### PR DESCRIPTION
Update the OData server's processing of incoming JSON DateTimeOffsets fields to handle the format YYYY-MM-DDTHH:mm:ssZ
