### PR TITLE
Fix memory leak

### DIFF
--- a/pyslet/odata2/csdl.py
+++ b/pyslet/odata2/csdl.py
@@ -2957,9 +2957,6 @@ class EntityCollection(DictionaryLike, PEP8Compatibility):
     def close(self):
         pass
 
-    def __del__(self):
-        self.close()
-
     def get_location(self):
         """Returns the location of this collection as a
         :py:class:`~pyslet.rfc2396.URI` instance.


### PR DESCRIPTION
With the `__del__` method in place for the `EntityCollection` class, it seems to cause a memory leak like they describe [here](https://mg.pov.lt/objgraph/uncollectable.html) for objgraph. With the `__del__` method in place, each time I fetched data via Odata, memory would go up. Without the `__del__` method, memory would go up occasionally, but would always go back down after a while when pythons GC kicked in.